### PR TITLE
use pdm for unknown chain id, likely is premainnet reset chain id

### DIFF
--- a/backend/context/config.py
+++ b/backend/context/config.py
@@ -24,7 +24,7 @@ class Config:
         return utils.account_address(self.vasp_address)
 
     def diem_address_hrp(self) -> str:
-        return identifier.HRPS[self.chain_id]
+        return identifier.HRPS.get(self.chain_id, identifier.PDM)
 
     def compliance_private_key(self) -> Ed25519PrivateKey:
         return Ed25519PrivateKey.from_private_bytes(

--- a/backend/tests/context_tests/test_config.py
+++ b/backend/tests/context_tests/test_config.py
@@ -53,3 +53,5 @@ def test_diem_address_hrp():
     assert conf.diem_address_hrp() == "dm"
     conf.chain_id = 2
     assert conf.diem_address_hrp() == "tdm"
+    conf.chain_id = 222
+    assert conf.diem_address_hrp() == "pdm"


### PR DESCRIPTION
Premainnet may reset chain id, all other chain ids are known, so use premainnet hrp if we found a new chain id.