### PR TITLE
Increased the internal inventory to 100K≋

### DIFF
--- a/backend/wallet/services/inventory.py
+++ b/backend/wallet/services/inventory.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import time
 from typing import Optional
 from uuid import UUID
@@ -29,7 +30,7 @@ from wallet.types import (
 logger = logging.getLogger(__name__)
 
 INVENTORY_COVER_CURRENCY = Currency.USD
-INVENTORY_AMOUNT = 10_000_000_000
+INVENTORY_AMOUNT = os.getenv("INVENTORY_AMOUNT", 100_000_000_000)
 
 
 def wait_for_trade_to_complete(trade_id):

--- a/backend/wallet/services/inventory.py
+++ b/backend/wallet/services/inventory.py
@@ -29,7 +29,7 @@ from wallet.types import (
 logger = logging.getLogger(__name__)
 
 INVENTORY_COVER_CURRENCY = Currency.USD
-INVENTORY_AMOUNT = 950_000_000
+INVENTORY_AMOUNT = 10_000_000_000
 
 
 def wait_for_trade_to_complete(trade_id):


### PR DESCRIPTION
Since the liquidity service can handle any amount both on testnet and premainnet, without the travel rule limitations, we should allow the wallet to handle funding above 1000≋.