### PR TITLE
Added support for InitPaymentCharge requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - develop
   push:
     branches:
       - master
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/dmw_test.yaml
+++ b/.github/workflows/dmw_test.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - develop
   push:
     branches:
       - master
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - develop
   push:
     branches:
       - master
+      - develop
 
 jobs:
   build:

--- a/backend/offchain/types/cid.py
+++ b/backend/offchain/types/cid.py
@@ -1,0 +1,7 @@
+import uuid
+
+
+def generate_cid() -> str:
+    return str(uuid.uuid4())
+
+


### PR DESCRIPTION

## Motivation

The main change in this PR is with the wallet off-chain commands.
In this change we fix the bug if sending the same `cid` twice and adding support in `InitPaymentCharge` response parsing.